### PR TITLE
Fix deployment workflow trust settings and enforce fullchain SSL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,8 +122,20 @@ jobs:
             # Navigate to project directory
             cd ${{ secrets.PROJECT_PATH }}
 
-            # Pull latest changes
-            git pull origin main
+            # Ensure Git trusts this working tree before pulling updates
+            if [ -d .git ]; then
+              git config --global --add safe.directory "$(pwd)"
+              git config --global --add safe.directory "${{ secrets.PROJECT_PATH }}"
+
+              if git remote get-url origin >/dev/null 2>&1; then
+                git fetch origin main --prune
+                git reset --hard origin/main
+              else
+                echo "Git remote 'origin' is not configured; skipping git pull."
+              fi
+            else
+              echo "No git metadata present; skipping git pull."
+            fi
 
             # Fix line endings for all shell scripts before building
             echo "Fixing line endings for shell scripts..."
@@ -162,15 +174,22 @@ jobs:
             
             # Ensure SSL certificates directory exists
             mkdir -p ssl
-            
+
+            SSL_DIR="/chasepay/ssl"
+
             # Check if SSL certificates exist and use appropriate nginx config
-            if [ -f "/chasepay/ssl/certificate.crt" ]; then
-              echo "SSL certificates found, using HTTPS configuration"
+            if [ -f "${SSL_DIR}/fullchain.crt" ] && [ -f "${SSL_DIR}/certificate.key" ]; then
+              echo "Fullchain SSL certificate found, using HTTPS configuration"
               # Remove HTTP-only config if it exists
               rm -f nginx/conf.d/default-http-only.conf
               # Keep the default.conf which has both HTTP and HTTPS
+            elif [ -f "${SSL_DIR}/certificate.crt" ] && [ -f "${SSL_DIR}/certificate_ca.crt" ] && [ -f "${SSL_DIR}/certificate.key" ]; then
+              echo "Fullchain SSL certificate missing; combining certificate.crt and certificate_ca.crt"
+              cat "${SSL_DIR}/certificate.crt" "${SSL_DIR}/certificate_ca.crt" > "${SSL_DIR}/fullchain.crt"
+              chmod 644 "${SSL_DIR}/fullchain.crt" || true
+              rm -f nginx/conf.d/default-http-only.conf
             else
-              echo "No SSL certificates found, using HTTP-only configuration"
+              echo "No complete SSL chain found, using HTTP-only configuration"
               # Remove the HTTPS config and use HTTP-only
               rm -f nginx/conf.d/default.conf
               cp nginx/conf.d/default-http-only.conf nginx/conf.d/default.conf

--- a/deploy.sh
+++ b/deploy.sh
@@ -34,12 +34,19 @@ fi
 # Ensure SSL certificates directory exists
 mkdir -p ssl
 
+SSL_DIR="ssl"
+
 # Choose nginx config based on SSL certificates
-if [ -f "ssl/certificate.crt" ]; then
-  echo "SSL certificates found, using HTTPS configuration"
+if [ -f "${SSL_DIR}/fullchain.crt" ] && [ -f "${SSL_DIR}/certificate.key" ]; then
+  echo "Fullchain SSL certificate found, using HTTPS configuration"
+  rm -f nginx/conf.d/default-http-only.conf
+elif [ -f "${SSL_DIR}/certificate.crt" ] && [ -f "${SSL_DIR}/certificate_ca.crt" ] && [ -f "${SSL_DIR}/certificate.key" ]; then
+  echo "Fullchain SSL certificate missing; combining certificate.crt and certificate_ca.crt"
+  cat "${SSL_DIR}/certificate.crt" "${SSL_DIR}/certificate_ca.crt" > "${SSL_DIR}/fullchain.crt"
+  chmod 644 "${SSL_DIR}/fullchain.crt" || true
   rm -f nginx/conf.d/default-http-only.conf
 else
-  echo "No SSL certificates found, using HTTP-only configuration"
+  echo "No complete SSL chain found, using HTTP-only configuration"
   rm -f nginx/conf.d/default.conf
   cp nginx/conf.d/default-http-only.conf nginx/conf.d/default.conf
   rm -f nginx/conf.d/default-http-only.conf

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,195 @@
+# Chase Payment Platform Configuration
+# This configuration handles both HTTP and HTTPS modes
+
+# HTTP server
+server {
+    listen 80;
+    listen [::]:80;
+    server_name chasepay.pro www.chasepay.pro;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Frontend proxy
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 86400;
+    }
+
+    # API proxy
+    location /api/ {
+        proxy_pass http://backend:3001/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+
+        # CORS headers
+        add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,x-trader-token,x-admin-key,x-merchant-token,x-agent-token,x-device-token' always;
+
+        if ($request_method = 'OPTIONS') {
+            return 204;
+        }
+    }
+
+    # Swagger documentation
+    location /swagger {
+        proxy_pass http://backend:3001/swagger;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket support for hot reload (only in dev, but harmless in prod)
+    location /_next/webpack-hmr {
+        proxy_pass http://frontend:3000/_next/webpack-hmr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    # Static files
+    location /_next/static {
+        proxy_pass http://frontend:3000;
+        proxy_cache_valid 60m;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Uploads directory
+    location /uploads {
+        alias /app/uploads;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+        add_header X-Content-Type-Options "nosniff" always;
+    }
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+}
+
+# HTTPS server - only included if SSL certificates are present
+# The SSL configuration below will be ignored if certificates don't exist
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name chasepay.pro www.chasepay.pro;
+
+    # SSL configuration
+    ssl_certificate /etc/nginx/ssl/fullchain.crt;
+    ssl_certificate_key /etc/nginx/ssl/certificate.key;
+    ssl_trusted_certificate /etc/nginx/ssl/certificate_ca.crt;
+
+    # SSL security settings
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    # Security headers
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Frontend proxy
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 86400;
+    }
+
+    # API proxy
+    location /api/ {
+        proxy_pass http://backend:3001/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+
+        # CORS headers
+        add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+        add_header 'Access-Control-Allow-Credentials' 'true' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Accept,Authorization,Cache-Control,Content-Type,DNT,If-Modified-Since,Keep-Alive,Origin,User-Agent,X-Requested-With,x-trader-token,x-admin-key,x-merchant-token,x-agent-token,x-device-token' always;
+
+        if ($request_method = 'OPTIONS') {
+            return 204;
+        }
+    }
+
+    # Swagger documentation
+    location /swagger {
+        proxy_pass http://backend:3001/swagger;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket support for hot reload (only in dev, but harmless in prod)
+    location /_next/webpack-hmr {
+        proxy_pass http://frontend:3000/_next/webpack-hmr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    # Static files
+    location /_next/static {
+        proxy_pass http://frontend:3000;
+        proxy_cache_valid 60m;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Uploads directory
+    location /uploads {
+        alias /app/uploads;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+        add_header X-Content-Type-Options "nosniff" always;
+    }
+
+    # Health check endpoint
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+}


### PR DESCRIPTION
## Summary
- add git safe.directory handling and more robust SSL validation to the deployment workflow
- align the local deploy script with the fullchain SSL expectations
- provide the default nginx configuration that terminates HTTPS with the full certificate chain

## Testing
- bash -n deploy.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9f79ddde48320b4b98e89b03b3087