### PR TITLE
Ensure deployment opens firewall for nginx

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,115 @@
 #!/bin/bash
 set -e
 
+#
+# Utility helpers
+#
+
+# Ensure that the host firewall (if any) allows inbound HTTP/HTTPS traffic so
+# that the nginx container exposed on ports 80/443 is reachable from outside
+# the server. This targets the most common firewall managers (ufw, firewalld
+# and plain iptables) and falls back to a warning if automatic configuration is
+# not possible.
+ensure_firewall_ports() {
+  echo "Ensuring firewall allows inbound HTTP/HTTPS traffic..."
+
+  if ! command -v id >/dev/null 2>&1; then
+    echo "Unable to determine current user – skipping firewall checks."
+    return
+  fi
+
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Skipping firewall configuration (requires root privileges)."
+    echo "Please ensure ports 80 and 443 are open on the host."
+    return
+  fi
+
+  local firewall_adjusted=0
+
+  if command -v ufw >/dev/null 2>&1; then
+    # Capture status only once to avoid repeated sub-shell invocations.
+    local ufw_status
+    ufw_status="$(ufw status 2>/dev/null || true)"
+    if printf '%s' "$ufw_status" | grep -q "Status: active"; then
+      for port in 80 443; do
+        if ! printf '%s' "$ufw_status" | grep -qE "^${port}/tcp\\b.*ALLOW"; then
+          echo "  Allowing ${port}/tcp via ufw"
+          ufw allow "${port}/tcp" >/dev/null 2>&1 || true
+          ufw_status="$(ufw status 2>/dev/null || true)"
+        fi
+      done
+      firewall_adjusted=1
+    fi
+  fi
+
+  if command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
+    echo "  Configuring firewalld services for HTTP/HTTPS"
+    firewall-cmd --permanent --add-service=http >/dev/null 2>&1 || true
+    firewall-cmd --permanent --add-service=https >/dev/null 2>&1 || true
+    firewall-cmd --reload >/dev/null 2>&1 || true
+    firewall_adjusted=1
+  fi
+
+  if [ "$firewall_adjusted" -eq 0 ] && command -v iptables >/dev/null 2>&1; then
+    for port in 80 443; do
+      if ! iptables -C INPUT -p tcp --dport "$port" -j ACCEPT >/dev/null 2>&1; then
+        echo "  Adding iptables rule to accept TCP port $port"
+        iptables -I INPUT -p tcp --dport "$port" -j ACCEPT >/dev/null 2>&1 || true
+      fi
+    done
+    if command -v netfilter-persistent >/dev/null 2>&1; then
+      netfilter-persistent save >/dev/null 2>&1 || true
+    fi
+    firewall_adjusted=1
+  fi
+
+  if [ "$firewall_adjusted" -eq 0 ]; then
+    echo "⚠️  Could not automatically adjust firewall rules."
+    echo "   Please verify manually that ports 80 and 443 are reachable from the Internet."
+  else
+    echo "Firewall configuration verified for ports 80/443."
+  fi
+}
+
+# Validate that nginx is reachable from the host network after the containers
+# are started. We probe the HTTP health endpoint exposed by nginx and warn (but
+# do not abort) if it cannot be reached – this keeps the deployment going while
+# highlighting potential networking issues such as blocked ports.
+verify_local_nginx() {
+  local ssl_dir="$1"
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl not available; skipping local nginx reachability check."
+    return
+  fi
+
+  echo "Verifying nginx availability on http://127.0.0.1:80/health ..."
+  local attempt=0
+  local max_attempts=10
+  while [ $attempt -lt $max_attempts ]; do
+    if curl -fsS --max-time 5 http://127.0.0.1/health >/dev/null 2>&1; then
+      echo "HTTP health check succeeded."
+      break
+    fi
+    attempt=$((attempt + 1))
+    sleep 3
+  done
+
+  if [ $attempt -ge $max_attempts ]; then
+    echo "⚠️  Unable to reach nginx on port 80 from the host after $max_attempts attempts."
+    echo "   Inspect firewall rules and docker logs if external access is still failing."
+  fi
+
+  if [ -n "$ssl_dir" ] && [ -f "$ssl_dir/fullchain.crt" ] && [ -f "$ssl_dir/certificate.key" ]; then
+    echo "Verifying nginx availability on https://127.0.0.1 (certificate ignored for localhost check)..."
+    if curl -kfsS --max-time 5 https://127.0.0.1 >/dev/null 2>&1; then
+      echo "HTTPS check succeeded."
+    else
+      echo "⚠️  HTTPS check failed. Ensure the SSL certificate/key pair is valid and nginx has restarted."
+    fi
+  fi
+}
+
 # Deploy Chase to production server locally after git pull
 # Requires environment variables: DATABASE_URL, JWT_SECRET, SUPER_ADMIN_KEY, ADMIN_IPS
 
@@ -12,6 +121,11 @@ if [ -z "${DATABASE_URL}" ] || [ -z "${JWT_SECRET}" ] || [ -z "${SUPER_ADMIN_KEY
   echo "ERROR: DATABASE_URL, JWT_SECRET, SUPER_ADMIN_KEY and ADMIN_IPS must be set"
   exit 1
 fi
+
+# Make sure the host will accept incoming traffic on ports 80/443 before we
+# spend time building images – if the firewall blocks these ports the services
+# will look healthy inside Docker but remain unreachable from the Internet.
+ensure_firewall_ports
 
 # Stop existing containers
 docker compose -f docker-compose.prod.yml down || true
@@ -163,6 +277,8 @@ SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' A
 SQL
 
 docker compose -f docker-compose.prod.yml ps
+
+verify_local_nginx "$SSL_DIR"
 
 docker system prune -af
 


### PR DESCRIPTION
## Summary
- add helper to `deploy.sh` that opens ports 80/443 through ufw, firewalld or iptables so nginx is reachable from the host network
- add post-deploy curl health check to confirm nginx responds over HTTP/HTTPS and emit actionable warnings when it does not

## Testing
- bash -n deploy.sh

------
https://chatgpt.com/codex/tasks/task_e_68ca197d2e108320913449bf1d335571