### PR TITLE
Fix production SSL mount path for nginx

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,7 +55,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
-      - /fenixpay/ssl:/etc/nginx/ssl:ro
+      - ./ssl:/etc/nginx/ssl:ro
       - ./nginx/logs:/var/log/nginx
     depends_on:
       - frontend


### PR DESCRIPTION
## Summary
- point the production nginx container to the repository ssl directory so that the provisioned certificates are available at runtime

## Testing
- not run (infrastructure change only)

------
https://chatgpt.com/codex/tasks/task_e_68ca200ea3d48320b262e7c51ac98829